### PR TITLE
Allow public bins CORS to accept all HTTP Verbs 

### DIFF
--- a/lib/routes/utils.js
+++ b/lib/routes/utils.js
@@ -7,7 +7,7 @@ function noCache(req, res, next) {
 }
 
 function cors(req, res, next) {
-  res.header('Access-Control-Allow-Methods', 'GET');
+  res.header('Access-Control-Allow-Methods', 'GET,POST,DELETE,PUT,PATCH');
   res.header('Access-Control-Allow-Origin', '*');
   res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
   next();


### PR DESCRIPTION
Allow public bins to accept all HTTP Verbs such as GET,POST,DELETE,PUT,PATCH.